### PR TITLE
Add readAll() method to SFE_PCA95XX for reading the entire input register

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,7 @@ setDebugStream	KEYWORD2
 invert	KEYWORD2
 revert	KEYWORD2
 getInputRegister	KEYWORD2
+readAll	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/SparkFun_I2C_Expander_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_Expander_Arduino_Library.cpp
@@ -296,6 +296,23 @@ uint8_t SFE_PCA95XX::digitalRead(uint8_t pin)
     return 0; // Unsafe
 }
 
+// Safe reading of all input pins
+PCA95XX_error_t SFE_PCA95XX::readAll(uint8_t *destination)
+{
+    return getInputRegister(destination);
+}
+
+// Unsafe overload
+uint8_t SFE_PCA95XX::readAll()
+{
+    uint8_t value;
+
+    if (readAll(&value) == PCA95XX_ERROR_SUCCESS)
+        return value;
+
+    return 0; // Unsafe
+}
+
 PCA95XX_error_t SFE_PCA95XX::invert(uint8_t pin, PCA95XX_invert_t inversion)
 {
     PCA95XX_error_t err;

--- a/src/SparkFun_I2C_Expander_Arduino_Library.h
+++ b/src/SparkFun_I2C_Expander_Arduino_Library.h
@@ -167,7 +167,7 @@ public:
 
   PCA95XX_error_t digitalRead(uint8_t *destination, uint8_t pin);
   uint8_t digitalRead(uint8_t pin); // May return erroneous data if read fails
-// Add in public section:
+
   PCA95XX_error_t readAll(uint8_t *destination); // Read all input pins
   uint8_t readAll();                             // Returns bitmask of all pins
 

--- a/src/SparkFun_I2C_Expander_Arduino_Library.h
+++ b/src/SparkFun_I2C_Expander_Arduino_Library.h
@@ -167,6 +167,9 @@ public:
 
   PCA95XX_error_t digitalRead(uint8_t *destination, uint8_t pin);
   uint8_t digitalRead(uint8_t pin); // May return erroneous data if read fails
+// Add in public section:
+  PCA95XX_error_t readAll(uint8_t *destination); // Read all input pins
+  uint8_t readAll();                             // Returns bitmask of all pins
 
   // invert and revert can be used to invert (or not) the I/O logic during a read
   PCA95XX_error_t invert(uint8_t pin, PCA95XX_invert_t inversion = PCA95XX_INVERT);


### PR DESCRIPTION
## Summary

This PR adds a `readAll()` method to `SFE_PCA95XX` to allow users to read the complete input register with a single function call.

## Changes

- Added a safe overload:

```cpp
PCA95XX_error_t readAll(uint8_t *destination);
```

- Added an unsafe overload:

```cpp
uint8_t readAll();
```

- Reused the existing `getInputRegister()` implementation to avoid code duplication while preserving the current library behavior.

## Motivation

This implements the feature requested in Issue #2 by providing a convenient API for reading all GPIO input states at once instead of reading individual pins.

## Testing

- Successfully compiled after adding the new API.
- The implementation reuses the existing `getInputRegister()` function, so no existing behavior is modified.

Fixes #2